### PR TITLE
Add a get_terminal_size function

### DIFF
--- a/tty/escape_seq.ml
+++ b/tty/escape_seq.ml
@@ -26,6 +26,7 @@ let erase_line_seq x = escape (Printf.sprintf "%dK" x)
 let scroll_up_seq x = escape (Printf.sprintf "%dS" x)
 let scroll_down_seq x = escape (Printf.sprintf "%dT" x)
 let save_cursor_position_seq = escape "s"
+let report_cursor_position_seq = escape "6n"
 let restore_cursor_position_seq = escape "u"
 let change_scrolling_region_seq x y = escape (Printf.sprintf "%d;%dr" x y)
 let insert_line_seq x = escape (Printf.sprintf "%dL" x)
@@ -57,6 +58,7 @@ let restore_screen_seq = escape "?47l"
 let save_screen_seq = escape "?47h"
 let alt_screen_seq = escape "?1049h"
 let exit_alt_screen_seq = escape "?1049l"
+let report_textarea_size_seq = escape "18t"
 
 (* Bracketed paste. *)
 let enable_bracketed_paste_seq = escape "?2004h"

--- a/tty/escape_seq.mli
+++ b/tty/escape_seq.mli
@@ -46,6 +46,8 @@ val erase_line_seq : int -> unit -> unit
 val exit_alt_screen_seq : unit -> unit
 val hide_cursor_seq : unit -> unit
 val insert_line_seq : int -> unit -> unit
+val report_textarea_size_seq : unit -> unit
+val report_cursor_position_seq : unit -> unit
 val restore_cursor_position_seq : unit -> unit
 val restore_screen_seq : unit -> unit
 val save_cursor_position_seq : unit -> unit

--- a/tty/terminal.ml
+++ b/tty/terminal.ml
@@ -19,6 +19,10 @@ let move_cursor x y = Escape_seq.cursor_position_seq x y ()
         over-writes any saved cursor position.
      - [Error `Unknown] *)
 let get_terminal_size ?(legacy = false) () =
+  let return rows cols =
+    try Ok (int_of_string rows, int_of_string cols)
+    with Failure _ -> Error `Interrupted
+  in
   let buf = Bytes.create 12 in
   let stdin_fd = Unix.descr_of_in_channel stdin in
   if legacy then (
@@ -41,6 +45,6 @@ let get_terminal_size ?(legacy = false) () =
           |> Bytes.to_string |> String.split_on_char ';'
         in
         match parts with
-        | [ "8"; rows; cols ] -> Ok (int_of_string rows, int_of_string cols)
-        | [ rows; cols ] -> Ok (int_of_string rows, int_of_string cols)
+        | [ "8"; rows; cols ] -> return rows cols
+        | [ rows; cols ] -> return rows cols
         | _ -> Error `Unsupported)

--- a/tty/terminal.ml
+++ b/tty/terminal.ml
@@ -9,3 +9,38 @@ let cursor_back x = Escape_seq.cursor_back_seq x ()
 let enter_alt_screen () = Escape_seq.alt_screen_seq ()
 let exit_alt_screen () = Escape_seq.exit_alt_screen_seq ()
 let move_cursor x y = Escape_seq.cursor_position_seq x y ()
+
+(** Return the dimensions of the active terminal as [Ok (rows, columns)] or
+    an error if unavailable:
+     - [Error `Interrupted] : Reading from STDIN was interrupted.
+     - [Error `Retry] : STDIN temporarily unavailable.
+     - [Error `Unsupported] : The terminal doesn't support XTWINOPS. Try
+        [get_terminal_size ~legacy:true ()], but be aware that this method
+        over-writes any saved cursor position.
+     - [Error `Unknown] *)
+let get_terminal_size ?(legacy = false) () =
+  let buf = Bytes.create 12 in
+  let stdin_fd = Unix.descr_of_in_channel stdin in
+  if legacy then (
+    Escape_seq.save_cursor_position_seq ();
+    Escape_seq.cursor_position_seq 999 999 ();
+    Escape_seq.report_cursor_position_seq ();
+    Escape_seq.restore_cursor_position_seq ())
+  else Escape_seq.report_textarea_size_seq ();
+  let ready, _, _ = Unix.select [ stdin_fd ] [] [] 0.01 in
+  if ready = [] then Error `Unsupported
+  else
+    match Unix.read stdin_fd buf 0 12 with
+    | exception Unix.(Unix_error (EINTR, _, _)) -> Error `Interrupted
+    | exception Unix.(Unix_error (EAGAIN, _, _)) -> Error `Retry
+    | exception Unix.(Unix_error (EWOULDBLOCK, _, _)) -> Error `Unsupported
+    | exception _ -> Error `Unknown
+    | len -> (
+        let parts =
+          Bytes.sub buf 2 (len - 3) (* drop the trailing 't' or 'R' *)
+          |> Bytes.to_string |> String.split_on_char ';'
+        in
+        match parts with
+        | [ "8"; rows; cols ] -> Ok (int_of_string rows, int_of_string cols)
+        | [ rows; cols ] -> Ok (int_of_string rows, int_of_string cols)
+        | _ -> Error `Unsupported)


### PR DESCRIPTION
I didn't get a reply to my [issue/feature request](https://github.com/ocaml-tui/tty/issues/6), but saw that it was added to the Riot roadmap, so maybe it is a feature you'd want in this library. _IANAP_, but this was functionality I missed so I had a crack at it anyway.  It's not pretty, but I was able to get the terminal dimensions in every terminal emulator I have installed, and with `~legacy:true` it works in the Linux console as well. 

Blocking for 0.01s seems like a lot, but `xfce4-terminal` (and presumably other VTE-based terminal emulators?) seems to need that much time to respond, at least on my machine.

I'm sure there's things I've overlooked, over-complicated, naming or style conventions I've broken etc. so feel free to treat this as a rough sketch and/or spam as you like, but any feedback would be welcome.